### PR TITLE
Use @slot instead of <x-slot...> for prettier code

### DIFF
--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -90,13 +90,19 @@
                             <x-mbc::CardActions>
 
                                 <!-- Button Actions -->
-                                <x-slot name="buttons">
-                                    <x-mbc::Button label="Read" />
-                                    <x-mbc::Button label="Bookmark" />
-                                </x-slot>
+                                @slot('buttons')
+                                    <x-mbc::button
+                                        variant="text"
+                                        label="Read"
+                                    />
+                                    <x-mbc::button
+                                        variant="text"
+                                        label="Bookmark"
+                                    />
+                                @endslot
 
                                 <!-- Icon Button Actions -->
-                                <x-slot name="iconButtons">
+                                @slot('iconButtons')
                                     <x-mbc::icon-button
                                         title="Add to favorites"
                                         aria-label="Add to favorites"
@@ -114,7 +120,7 @@
                                         aria-label="More options"
                                         icon="more_vert"
                                     />
-                                </x-slot>
+                                @endslot
                             </x-mbc::CardActions>
                         </x-mbc::Card>
 
@@ -269,7 +275,7 @@
                                     />
 
                                     <x-mbc::CardActions>
-                                        <x-slot:icon-buttons>
+                                        @slot('icon-buttons')
                                             <x-mbc::icon-button
                                                 title="Previous"
                                                 icon="skip_previous"
@@ -283,7 +289,7 @@
                                                 title="Next"
                                                 icon="skip_next"
                                             />
-                                        </x-slot:icon-buttons>
+                                        @endslot
                                     </x-mbc::CardActions>
                                 </div>
                             </div>

--- a/resources/views/layouts/docs/parts/nav.blade.php
+++ b/resources/views/layouts/docs/parts/nav.blade.php
@@ -2,12 +2,12 @@
     style="position: fixed; top:0; left: 0; height: 100vh; overflow-y: auto;"
     subtitle="Documentation"
 >
-    <x-slot:title>
+    @slot('title')
         <a
             href="{{ route('index') }}"
             style="color: inherit; text-decoration: none;"
         >Material Blade</a>
-    </x-slot:title>
+    @endslot
 
     <x-mbc::list
         element="nav"

--- a/resources/views/pages/blank-page-template.blade.php
+++ b/resources/views/pages/blank-page-template.blade.php
@@ -44,4 +44,3 @@
         </x-mbc::typography>
     </section>
 @endsection
-

--- a/resources/views/pages/components/button/index.blade.php
+++ b/resources/views/pages/components/button/index.blade.php
@@ -86,7 +86,7 @@
 
 // set the button text via "label" attribute
 &lt;x-mbc::button label="Anynomus Component" />
-            {{-- prettier-ignore-end --}}
+{{-- prettier-ignore-end--}}
             @endslot
         </x-component-preview>
     </section>
@@ -144,7 +144,7 @@
     label="Outlined"
     variant="outlined"
 />
-                {{-- prettier-ignore-end --}}
+{{-- prettier-ignore-end--}}
             @endslot
         </x-component-preview>
     </section>
@@ -188,7 +188,7 @@
     label="Div Button"
     htmlTag="div"
 />
-                {{-- prettier-ignore-end --}}
+{{-- prettier-ignore-end--}}
             @endslot
         </x-component-preview>
     </section>
@@ -238,7 +238,7 @@
     startIcon="noise_control_off"
     endIcon="disabled_by_default"
 />
-                {{-- prettier-ignore-end --}}
+{{-- prettier-ignore-end--}}
             @endslot
         </x-component-preview>
 
@@ -292,9 +292,8 @@
     :startIcon="['noise_control_off', 'round']"
     :endIcon="['disabled_by_default', 'sharp']"
 />
-                {{-- prettier-ignore-end --}}
+{{-- prettier-ignore-end--}}
             @endslot
         </x-component-preview>
     </section>
 @endsection
-

--- a/resources/views/pages/components/fab/index.blade.php
+++ b/resources/views/pages/components/fab/index.blade.php
@@ -48,10 +48,8 @@
         <x-component-preview>
             <x-mbc::fab icon="favorite" />
 
-            @slot('codeSummary')
-                {{-- prettier-ignore-start --}}
-&lt;x-mbc::fab icon="favorite" />
-                {{-- prettier-ignore-end --}}
+            @slot('code-summary')
+                &lt;x-mbc::fab icon="favorite" />
             @endslot
         </x-component-preview>
     </section>
@@ -75,7 +73,7 @@
                 {{-- prettier-ignore-start --}}
 &lt;x-mbc::fab icon="add" variant="regular" />
 &lt;x-mbc::fab icon="add" variant="mini" />
-                {{-- prettier-ignore-end --}}
+{{-- prettier-ignore-end--}}
             @endslot
         </x-component-preview>
     </section>
@@ -98,9 +96,8 @@
                 {{-- prettier-ignore-start --}}
 &lt;x-mbc::fab label="Order" />
 &lt;x-mbc::fab icon="add" label="Create" />
-                {{-- prettier-ignore-end --}}
+{{-- prettier-ignore-end--}}
             @endslot
         </x-component-preview>
     </section>
 @endsection
-

--- a/resources/views/pages/components/icon-button/index.blade.php
+++ b/resources/views/pages/components/icon-button/index.blade.php
@@ -1,0 +1,336 @@
+@php
+    $pageData = [
+        'title' => 'Icon Button',
+        'metas' => [
+            'description' => 'Icon buttons allow users to take actions, and make choices, with a single tap.',
+        ],
+        'headings' => ['Basic', 'Color', 'Toggle Button', 'Toggle Off Icon', 'Render as Anchor Tag', 'Ripple Disabled'],
+        'referenceLinks' => [
+            'https://mui.com/material-ui/react-icon-button/',
+            'https://m2.material.io/develop/web/components/buttons/icon-buttons',
+            'https://github.com/material-components/material-components-web/blob/v14.0.0/packages/mdc-icon-button/README.md',
+            'https://material-components.github.io/material-components-web-catalog/#/component/icon-button',
+        ],
+        'componentsProps' => [
+            'mbc::icon-button' => [
+                ['icon', 'string', 'null', 'The name of the icon.'],
+                ['color', 'string', 'null', 'The color of the icon.'],
+                ['toggle', 'boolean', 'false', 'If true, the icon button will be a toggle button.'],
+                ['toggle', 'string', 'null', 'The toggle state of the icon button.'],
+                ['offIcon', 'string', 'null', 'The name of the icon when the toggle is off.'],
+                ['href', 'string', 'null', 'The URL to link to when the button is clicked.'],
+                ['disableRipple', 'boolean', 'false', 'If true, the ripple effect will be disabled.'],
+                ['withWrapper', 'boolean', 'false', 'If true, the icon button will be wrapped with a div element.'],
+                ['disabled', 'boolean', 'false', 'If true, the icon button will be disabled.'],
+            ],
+        ],
+    ];
+@endphp
+
+@extends('layouts.docs', $pageData)
+
+@section('description')
+    <x-mbc::typography>{{ $pageData['metas']['description'] }}</x-mbc::typography>
+
+    <x-mbc::alert
+        title="Note"
+        severity="info"
+    >
+        For buttons with both icons and text, use the <code>mbc::button</code> component. For more information, see the
+        <x-mbc::button
+            href="{{ route('components.button') }}"
+            label="Button page"
+            variant="text"
+        />.
+    </x-mbc::alert>
+@endsection
+
+@section('content')
+    <section>
+        <x-h2>
+            Basic
+        </x-h2>
+
+        <x-component-preview>
+            <div style="display: flex;">
+                <x-mbc::icon-button icon="delete" />
+                <x-mbc::icon-button icon="send" />
+                <x-mbc::icon-button icon="share" />
+            </div>
+
+            @slot('code-summary')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon-button icon="icon name | [icon name, icon variant]" />
+{{-- prettier-ignore-end--}}
+            @endslot
+
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon-button icon="delete" />
+&lt;x-mbc::icon-button icon="send" />
+&lt;x-mbc::icon-button icon="share" />
+{{-- prettier-ignore-end--}}
+            @endslot
+        </x-component-preview>
+    </section>
+
+    <section>
+        <x-h2>
+            Color
+        </x-h2>
+
+        <x-component-preview>
+            <div style="display: flex;">
+                <x-mbc::icon-button icon="home" />
+                <x-mbc::icon-button
+                    icon="bluetooth"
+                    color="primary"
+                />
+                <x-mbc::icon-button
+                    icon="filter_vintage"
+                    color="secondary"
+                />
+                <x-mbc::icon-button
+                    icon="delete"
+                    color="error"
+                />
+                <x-mbc::icon-button
+                    icon="paid"
+                    color="warning"
+                />
+                <x-mbc::icon-button
+                    icon="power_settings_new"
+                    color="info"
+                />
+                <x-mbc::icon-button
+                    icon="check_circle"
+                    color="success"
+                />
+            </div>
+
+            @slot('code-summary')
+                {{-- prettier-ignore-start --}}
+                &lt;x-mbc::icon-button .... color="css color | theme color" />
+{{-- prettier-ignore-end--}}
+            @endslot
+
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon-button icon="home" />
+&lt;x-mbc::icon-button
+    icon="bluetooth"
+    color="primary"
+/>
+&lt;x-mbc::icon-button
+    icon="filter_vintage"
+    color="secondary"
+/>
+&lt;x-mbc::icon-button
+    icon="delete"
+    color="error"
+/>
+&lt;x-mbc::icon-button
+    icon="paid"
+    color="warning"
+/>
+&lt;x-mbc::icon-button
+    icon="power_settings_new"
+    color="info"
+/>
+&lt;x-mbc::icon-button
+    icon="check_circle"
+    color="success"
+/>
+{{-- prettier-ignore-end--}}
+            @endslot
+        </x-component-preview>
+    </section>
+
+    <section>
+        <x-h2>
+            Toggle Button
+        </x-h2>
+
+        <x-component-preview>
+            <div style="display: flex;">
+                <x-mbc::icon-button
+                    icon="home"
+                    toggle
+                />
+                <x-mbc::icon-button
+                    icon="power_settings_new"
+                    color="info"
+                    toggle="on"
+                />
+                <x-mbc::icon-button
+                    icon="check_circle"
+                    color="success"
+                    toggle
+                />
+                <x-mbc::icon-button
+                    icon="send"
+                    color="secondary"
+                    toggle="on"
+                    disabled
+                />
+                <x-mbc::icon-button
+                    icon="photo_camera"
+                    color="secondary"
+                    toggle="off"
+                    disabled
+                />
+            </div>
+
+            @slot('code-summary')
+                &lt;x-mbc::icon-button .... toggle />
+            @endslot
+
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon-button icon="home" toggle />
+&lt;x-mbc::icon-button icon="power_settings_new" color="info" toggle="on" />
+&lt;x-mbc::icon-button icon="check_circle" color="success" toggle />
+&lt;x-mbc::icon-button icon="send" color="secondary" toggle="on" disabled />
+&lt;x-mbc::icon-button icon="photo_camera" color="secondary" toggle="off" disabled />
+{{-- prettier-ignore-end--}}
+            @endslot
+        </x-component-preview>
+    </section>
+
+    <section>
+        <x-h2>
+            Toggle Off Icon
+        </x-h2>
+
+        <x-mbc::typography>
+            By default the <code>OFF</code> state icon of toggle button same with the <code>ON</code> state icon, if you
+            want
+            to change the <code>OFF</code> state icon you can simply add the <code>offIcon</code> attribute.
+        </x-mbc::typography>
+
+        <x-component-preview>
+            <div style="display: flex;">
+                <x-mbc::icon-button
+                    icon="fullscreen_exit"
+                    offIcon="fullscreen"
+                    toggle
+                />
+                <x-mbc::icon-button
+                    icon="wifi"
+                    offIcon="wifi_off"
+                    toggle="on"
+                />
+                <x-mbc::icon-button
+                    icon="favorite"
+                    :offIcon="['favorite', 'two-tone']"
+                    toggle
+                    color="error"
+                />
+            </div>
+
+            @slot('code-summary')
+                {{-- prettier-ignore-start --}}
+                &lt;x-mbc::icon-button .... offIcon="icon name | [icon name, icon variant]" toggle />
+{{-- prettier-ignore-end--}}
+            @endslot
+
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon-button icon="fullscreen_exit" offIcon="fullscreen" toggle />
+&lt;x-mbc::icon-button icon="wifi" offIcon="wifi_off" toggle="on" />
+&lt;x-mbc::icon-button icon="favorite" offIcon="favorite:two-tone" toggle color="error" />
+{{-- prettier-ignore-end--}}
+            @endslot
+        </x-component-preview>
+    </section>
+
+    <section>
+        <x-h2>
+            Render as Anchor Tag
+        </x-h2>
+
+        <x-mbc::typography>
+            By default the <code>mbc::icon-button</code> will be rendered as <code>&lt;button></code> element. If you want
+            to
+            make it an <code>&lt;a></code> element please add <code>href</code> attribute to the
+            <code>mbc::icon-button</code>.
+            If you add the <code>disabled</code> attribute the <code>mbc::icon-button</code> will be rendered as disabled
+            <code>button</code>.
+        </x-mbc::typography>
+
+        <x-component-preview>
+            <div style="display: flex;">
+                <x-mbc::icon-button
+                    icon="mail"
+                    href="mailto:zainadam.id@gmail.com"
+                />
+                <x-mbc::icon-button
+                    icon="phone"
+                    color="success"
+                    href="tel: +123 456 789"
+                />
+                <x-mbc::icon-button
+                    icon="phone"
+                    color="success"
+                    href="tel: +123 456 789"
+                    disabled
+                />
+            </div>
+
+            @slot('code-summary')
+                &lt;x-mbc::icon-button .... href="url" />
+            @endslot
+
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon-button icon="mail" href="mailto:zainadam.id@gmail.com" />
+&lt;x-mbc::icon-button icon="phone" color="success" href="tel: +123 456 789" />
+&lt;x-mbc::icon-button icon="phone" color="success" href="tel: +123 456 789" disabled />
+{{-- prettier-ignore-end--}}
+            @endslot
+        </x-component-preview>
+    </section>
+
+    <section>
+        <x-h2>
+            Ripple Disabled
+        </x-h2>
+
+        <x-mbc::typography>
+            Just add the <code>disableRipple</code> attribute to the <code>mbc::icon-button</code> component. however,
+            disabling
+            ripple make button not hard to be recognized by user, please add the hover style.
+        </x-mbc::typography>
+
+        <x-component-preview>
+            <div style="display: flex;">
+                <x-mbc::icon-button
+                    icon="home"
+                    disableRipple
+                />
+                <x-mbc::icon-button
+                    icon="close"
+                    color="error"
+                    disableRipple
+                />
+                <x-mbc::icon-button
+                    icon="logout"
+                    color="success"
+                    disableRipple
+                />
+            </div>
+
+            @slot('code-summary')
+                &lt;x-mbc::icon-button .... ripple="false" />
+            @endslot
+
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon-button icon="home" ripple="false" />
+&lt;x-mbc::icon-button icon="close" color="error" ripple="false" />
+&lt;x-mbc::icon-button icon="logout" color="success" ripple="false" />
+{{-- prettier-ignore-end--}}
+            @endslot
+        </x-component-preview>
+    </section>
+@endsection

--- a/resources/views/pages/components/icon/index.blade.php
+++ b/resources/views/pages/components/icon/index.blade.php
@@ -69,17 +69,21 @@
                 />
             </div>
 
-            <x-slot:code-summary>&lt;x-mbc::icon name="icon name | [icon name, variant]" ... /></x-slot:code-summary>
+            @slot('code-summary')
+                &lt;x-mbc::icon name="icon name | [icon name, variant]" ... />
+            @endslot
 
-            {{-- prettier-ignore-start --}}
-            <x-slot:code>&lt;x-mbc::icon name="home" />
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon name="home" />
 &lt;x-mbc::icon name="['settings', 'outlined']" />
 &lt;x-mbc::icon :name="['delete', 'round']" />
 &lt;x-mbc::icon
     name="lock"
     variant="two-tone"
-/></x-slot:code>
-                {{-- prettier-ignore-end --}}
+/>
+{{-- prettier-ignore-end--}}
+            @endslot
         </x-component-preview>
 
         <x-mbc::typography>
@@ -144,10 +148,13 @@
                 />
             </div>
 
-            <x-slot:code-summary>&lt;x-mbc::icon variant="icon variant" ... /></x-slot:code-summary>
+            @slot('code-summary')
+                &lt;x-mbc::icon variant="icon variant" ... />
+            @endslot
 
-            {{-- prettier-ignore-start --}}
-            <x-slot:code>&lt;x-mbc::icon name="home" />
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon name="home" />
 
 &lt;x-mbc::icon
 name="home"
@@ -172,8 +179,9 @@ variant="sharp"
 &lt;x-mbc::icon
 name="home"
 variant="two-tone"
-/></x-slot:code>
-            {{-- prettier-ignore-end --}}
+/>
+{{-- prettier-ignore-end--}}
+            @endslot
         </x-component-preview>
     </section>
 
@@ -212,30 +220,38 @@ variant="two-tone"
                 />
             </div>
 
-            <x-slot:code-summary>&lt;x-mbc::icon fontSize="font size" ... /></x-slot:code-summary>
+            @slot('code-summary')
+                &lt;x-mbc::icon fontSize="font size" ... />
+            @endslot
 
-            {{-- prettier-ignore-start --}}
-            <x-slot:code>&lt;x-mbc::icon
-name="home"
-fontSize="1rem"
-/>
+            @slot('code')
+                {{-- prettier-ignore-start --}}
 &lt;x-mbc::icon
-name="home"
-fontSize="2rem"
+    name="home"
+    fontSize="1rem"
 />
+
 &lt;x-mbc::icon
-name="home"
-fontSize="3rem"
+    name="home"
+    fontSize="2rem"
 />
+
 &lt;x-mbc::icon
-name="home"
-fontSize="4rem"
+    name="home"
+    fontSize="3rem"
 />
+
 &lt;x-mbc::icon
-name="home"
-fontSize="5rem"
-/></x-slot:code>
-            {{-- prettier-ignore-end --}}
+    name="home"
+    fontSize="4rem"
+/>
+
+&lt;x-mbc::icon
+    name="home"
+    fontSize="5rem"
+/>
+{{-- prettier-ignore-end--}}
+            @endslot
         </x-component-preview>
     </section>
 
@@ -288,10 +304,13 @@ fontSize="5rem"
                 />
             </div>
 
-            <x-slot:code-summary>&lt;x-mbc::icon color="color name" ... /></x-slot:code-summary>
+            @slot('code-summary')
+                &lt;x-mbc::icon color="css color | mbc theme color" ... />
+            @endslot
 
-            {{-- prettier-ignore-start --}}
-            <x-slot:code>&lt;x-mbc::icon name="home" />
+            @slot('code')
+                {{-- prettier-ignore-start --}}
+&lt;x-mbc::icon name="home" />
 
 &lt;x-mbc::icon
     name="bluetooth"
@@ -331,8 +350,9 @@ fontSize="5rem"
 &lt;x-mbc::icon
     name="colorize"
     color="aqua"
-/></x-slot:code>
-            {{-- prettier-ignore-end --}}
+/>
+{{-- prettier-ignore-end--}}
+            @endslot
         </x-component-preview>
     </section>
 @endsection

--- a/resources/views/pages/components/list/parts/basic-section-body.blade.php
+++ b/resources/views/pages/components/list/parts/basic-section-body.blade.php
@@ -22,17 +22,22 @@
         </x-mbc::list-item>
     </x-mbc::list>
 
-    {{-- prettier-ignore-start --}}
-    <x-slot:code-summary>&lt;x-mbc::list>
+    @slot('code-summary')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list>
     &lt;x-mbc::list-item>
         Item 1
     &lt;/x-mbc::list-item>
 
     // Other list items
     // ....
-&lt;/x-mbc::list></x-slot:code-summary>
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 
-    <x-slot:code>&lt;x-mbc::list>
+    @slot('code')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list>
     &lt;x-mbc::list-item>
         Item 1
     &lt;/x-mbc::list-item>
@@ -44,7 +49,7 @@
     &lt;x-mbc::list-item>
         Item 3
     &lt;/x-mbc::list-item>
-&lt;/x-mbc::list></x-slot:code>
-        {{-- prettier-ignore-end --}}
-
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 </x-component-preview>

--- a/resources/views/pages/components/list/parts/dense-list-section-body.blade.php
+++ b/resources/views/pages/components/list/parts/dense-list-section-body.blade.php
@@ -23,13 +23,18 @@
         </x-mbc::list-item>
     </x-mbc::list>
 
-    {{-- prettier-ignore-start --}}
-    <x-slot:code-summary>&lt;x-mbc::list dense>
+    @slot('code-summary')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list dense>
     // list items
     // ....
-&lt;/x-mbc::list></x-slot:code-summary>
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 
-    <x-slot:code>&lt;x-mbc::list dense>
+    @slot('code')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list dense>
     &lt;x-mbc::list-item>
         Item 1
     &lt;/x-mbc::list-item>
@@ -47,6 +52,7 @@
     &lt;x-mbc::list-item>
         Item 4
     &lt;/x-mbc::list-item>
-&lt;/x-mbc::list></x-slot:code>
-    {{-- prettier-ignore-end --}}
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 </x-component-preview>

--- a/resources/views/pages/components/list/parts/divider-section-body.blade.php
+++ b/resources/views/pages/components/list/parts/divider-section-body.blade.php
@@ -15,8 +15,9 @@
         </x-mbc::list-item>
     </x-mbc::list>
 
-    {{-- prettier-ignore-start --}}
-    <x-slot:code-summary>&lt;x-mbc::list>
+    @slot('code-summary')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list>
     // list items
     // ....
 
@@ -24,9 +25,13 @@
 
     // other list items
     // ....
-&lt;/x-mbc::list></x-slot:code-summary>
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 
-    <x-slot:code>&lt;x-mbc::list>
+    @slot('code')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list>
     &lt;x-mbc::list-item>
         Item 1
     &lt;/x-mbc::list-item>
@@ -36,6 +41,7 @@
     &lt;x-mbc::list-item>
         Item 2
     &lt;/x-mbc::list-item>
-&lt;/x-mbc::list></x-slot:code>
-    {{-- prettier-ignore-end --}}
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 </x-component-preview>

--- a/resources/views/pages/components/list/parts/leading-and-trailing-section-body.blade.php
+++ b/resources/views/pages/components/list/parts/leading-and-trailing-section-body.blade.php
@@ -20,8 +20,9 @@
         </x-mbc::list-item>
     </x-mbc::list>
 
-    {{-- prettier-ignore-start --}}
-    <x-slot:code>&lt;x-mbc::list>
+    @slot('code-summary')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list>
     &lt;x-mbc::list-item startIcon="star">
         Leading Icon
     &lt;/x-mbc::list-item>
@@ -35,9 +36,10 @@
         endIcon="bluetooth"
     >
         Both
-    &lt;    /x-mbc::list-item>
-&lt;/x-mbc::list></x-slot:code>
-    {{-- prettier-ignore-end --}}
+    &lt;/x-mbc::list-item>
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 </x-component-preview>
 
 <x-mbc::typography>
@@ -60,9 +62,11 @@
         >
             Leading and Trailing Image
         </x-mbc::list-item>
+    </x-mbc::list>
 
+    @slot('code-summary')
         {{-- prettier-ignore-start --}}
-    <x-slot:code>&lt;x-mbc::list>
+&lt;x-mbc::list>
     &lt;x-mbc::list-item startIcon="https://picsum.photos/id/1/200">
         Leading Image
     &lt;/x-mbc::list-item>
@@ -77,9 +81,9 @@
     >
         Both
     &lt;/x-mbc::list-item>
-&lt;/x-mbc::list></x-slot:code>
-    {{-- prettier-ignore-end --}}
-    </x-mbc::list>
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 </x-component-preview>
 
 <x-mbc::typography>
@@ -98,8 +102,9 @@
         </x-mbc::list-item>
     </x-mbc::list>
 
-    {{-- prettier-ignore-start --}}
-    <x-slot:code>&lt;x-mbc::list avatar>
+    @slot('code-summary')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list avatar>
     &lt;x-mbc::list-item startIcon="folder">
         Avatar Icon
     &lt;/x-mbc::list-item>
@@ -107,6 +112,7 @@
     &lt;x-mbc::list-item startIcon="https://picsum.photos/id/64/200">
         Avatar Image
     &lt;/x-mbc::list-item>
-&lt;/x-mbc::list></x-slot:code>
-    {{-- prettier-ignore-end --}}
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 </x-component-preview>

--- a/resources/views/pages/components/list/parts/variant-section-body.blade.php
+++ b/resources/views/pages/components/list/parts/variant-section-body.blade.php
@@ -26,17 +26,22 @@
         />
     </x-mbc::list>
 
-    {{-- prettier-ignore-start --}}
-    <x-slot:code-summary>&lt;x-mbc::list variant="two-line">
+    @slot('code-summary')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list variant="two-line">
     &lt;x-mbc::list-item
         primary="Item 1"
         secondary="secondary line"
     />
 
     // other items
-&lt;/x-mbc::list></x-slot:code-summary>
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 
-<x-slot:code>&lt;x-mbc::list variant="two-line">
+    @slot('code')
+        {{-- prettier-ignore-start --}}
+&lt;x-mbc::list variant="two-line">
     &lt;x-mbc::list-item
         primary="Item 1"
         secondary="secondary line"
@@ -48,6 +53,7 @@
         primary="Item 3"
         secondary="secondary line"
     />
-&lt;/x-mbc::list></x-slot:code>
-    {{-- prettier-ignore-end --}}
+&lt;/x-mbc::list>
+{{-- prettier-ignore-end --}}
+    @endslot
 </x-component-preview>


### PR DESCRIPTION
This pull request fixes issue #6 by replacing the usage of `<x-slot>` with `@slot` in the code. This change improves the readability and maintainability of the code. Additionally, this pull request includes a new feature: `IconButton` page.